### PR TITLE
Broader exception handling

### DIFF
--- a/src/system_fingerprint/imprint.py
+++ b/src/system_fingerprint/imprint.py
@@ -1,5 +1,6 @@
 import argparse
 import pathlib
+import sys
 import yaml
 
 from ros_system_fingerprint import modules
@@ -16,8 +17,8 @@ def main():
     for module in modules:
         try:
             D[module.__name__] = module()
-        except ConnectionRefusedError:
-            pass
+        except Exception as e:
+            print(f'{repr(e)} occurred when fingerprinting {module.__name__}. Skipping...', file=sys.stderr)
 
     contents = yaml.safe_dump(D)
 


### PR DESCRIPTION
Handle all exceptions in the individual modules so that as many modules as possible can complete.

(would catch the error @tylerjw had in #7 )